### PR TITLE
WIP: Move internal dates to canonical ISO (YYYY-MM-DD) — DO NOT MERGE - branch: Fix/move to canonical date string

### DIFF
--- a/__tests__/Manager.test.js
+++ b/__tests__/Manager.test.js
@@ -63,7 +63,7 @@ describe('Manager tests', () => {
   const O2 = actionSpecs.Expiry2.Offset;
   const O3 = actionSpecs.Expiry3.Offset;
   const O4 = actionSpecs.Expiry4.Offset;
-  const today = utils.dateOnly("2025-03-01")
+  const today = utils.toIsoDateString("2025-03-01")
   let manager;
   let activeMembers;
   let expiredMembers;
@@ -94,9 +94,9 @@ describe('Manager tests', () => {
   describe('processExpirations', () => {
     beforeEach(() => {
       expirySchedule = [
-        { Date: new Date('2050-01-01'), Type: utils.ActionType.Expiry1, Email: "test1@example.com" },
+  { Date: '2050-01-01', Type: utils.ActionType.Expiry1, Email: "test1@example.com" },
         { Date: today, Type: utils.ActionType.Expiry2, Email: "test2@example.com" },
-        { Date: new Date('2045-01-01'), Type: utils.ActionType.Expiry3, Email: "test3@example.com" },
+  { Date: '2045-01-01', Type: utils.ActionType.Expiry3, Email: "test3@example.com" },
         { Date: today, Type: utils.ActionType.Expiry4, Email: "test4@example.com" }
       ];
     });
@@ -119,7 +119,7 @@ describe('Manager tests', () => {
       expect(consoleSpy).toHaveBeenCalledWith("Skipping member test1@example.com - they're not an active member");
     })
     it('should remove the expiry schedule even if the member cannot be expired', () => {
-      const expectedExpirySchedule = expirySchedule.filter(e => e.Date > new Date(today)).map(e => { return { ...e } });
+  const expectedExpirySchedule = expirySchedule.filter(e => e.Date > today).map(e => { return { ...e } });
       manager.processExpirations(activeMembers, expirySchedule, PREFILL_FORM_TEMPLATE);
       expect(expirySchedule).toEqual(expectedExpirySchedule);
     })
@@ -185,9 +185,9 @@ describe('Manager tests', () => {
 
       it('should amend the expiry schedule list appropriately', () => {
         let expectedExpirySchedule = [
-          { Date: new Date('2050-01-01'), Type: utils.ActionType.Expiry1, Email: "test1@example.com" },
-          { Date: new Date('2045-01-01'), Type: utils.ActionType.Expiry3, Email: "test3@example.com" },
-        ];
+            { Date: '2050-01-01', Type: utils.ActionType.Expiry1, Email: "test1@example.com" },
+            { Date: '2045-01-01', Type: utils.ActionType.Expiry3, Email: "test3@example.com" },
+          ];
         manager.processExpirations(activeMembers, expirySchedule, PREFILL_FORM_TEMPLATE);
         expect(expirySchedule).toEqual(expectedExpirySchedule)
       })
@@ -229,7 +229,7 @@ describe('Manager tests', () => {
       it('should remove all schedules for the expiring member', () => {
         expirySchedule.push({ Date: utils.addDaysToDate(today, +3), Type: utils.ActionType.Expiry2, Email: "test1@example.com" })
         manager.processExpirations(activeMembers, expirySchedule, PREFILL_FORM_TEMPLATE);
-        expect(expirySchedule).toEqual([{ Date: new Date('2099-10-10:00:00:00Z'), Type: utils.ActionType.Expiry2, Email: "test2@example.com" }]);
+  expect(expirySchedule).toEqual([{ Date: '2099-10-10', Type: utils.ActionType.Expiry2, Email: "test2@example.com" }]);
       })
     });
     describe('Expiry4 processing', () => {
@@ -559,7 +559,7 @@ describe('Manager tests', () => {
             Last: "Doe",
             Joined: joinDate,
             Expires: utils.addYearsToDate(activeMembers[0].Expires, 1),
-            "Renewed On": manager.today(),
+            "Renewed On": utils.toIsoDateString(manager.today()),
             Status: "Active",
             "Directory Share Name": false,
             "Directory Share Email": false,
@@ -580,7 +580,7 @@ describe('Manager tests', () => {
             Last: "Doe",
             Joined: joinDate,
             Expires: utils.addYearsToDate(manager.today(), 1),
-            "Renewed On": manager.today(),
+            "Renewed On": utils.toIsoDateString(manager.today()),
             Status: "Active",
             "Directory Share Name": false,
             "Directory Share Email": false,
@@ -677,30 +677,30 @@ describe('Manager tests', () => {
 
     beforeEach(() => {
       expirySchedule = [
-        { Date: new Date('2023-01-01'), Email: 'test@example.com', Type: utils.ActionType.Expiry1 },
-        { Date: new Date('2023-02-01'), Email: 'test@example.com', Type: utils.ActionType.Expiry2 }
+  { Date: '2023-01-01', Email: 'test@example.com', Type: utils.ActionType.Expiry1 },
+  { Date: '2023-02-01', Email: 'test@example.com', Type: utils.ActionType.Expiry2 }
       ];
       emailSpecs = actionSpecsArray
       member = {
         Email: 'test@example1.com',
         First: 'John',
         Last: 'Doe',
-        Joined: new Date('2022-01-01'),
+  Joined: '2022-01-01',
         Period: 1,
-        Expires: new Date('2023-01-01'),
-        "Renewed On": new Date('2023-01-01')
+  Expires: '2023-01-01',
+  "Renewed On": '2023-01-01'
       };
     });
 
     it('should remove existing action schedule entries for the member', () => {
-      const member = { Email: "test1@example.com", Period: 1, first: "John", last: "Doe", Joined: utils.dateOnly('2021-01-01'), Expires: utils.addYearsToDate(today, 1), "Renewed On": today };
+  const member = { Email: "test1@example.com", Period: 1, first: "John", last: "Doe", Joined: '2021-01-01', Expires: utils.addYearsToDate(today, 1), "Renewed On": today };
       const expected = [
         { Email: member.Email, Type: utils.ActionType.Expiry1, Date: utils.addDaysToDate(member.Expires, O1), },
         { Email: member.Email, Type: utils.ActionType.Expiry2, Date: utils.addDaysToDate(member.Expires, O2), },
         { Email: member.Email, Type: utils.ActionType.Expiry3, Date: utils.addDaysToDate(member.Expires, O3), },
         { Email: member.Email, Type: utils.ActionType.Expiry4, Date: utils.addDaysToDate(member.Expires, O4), }
       ]
-      expirySchedule = [{ Email: member.Email, Type: utils.ActionType.Expiry3, Date: utils.dateOnly('2021-01-10'), },
+  expirySchedule = [{ Email: member.Email, Type: utils.ActionType.Expiry3, Date: '2021-01-10', },
       ]
       manager.addRenewedMemberToActionSchedule_(member, expirySchedule, emailSpecs);
       expect(expirySchedule).toEqual(expected);
@@ -708,7 +708,7 @@ describe('Manager tests', () => {
     });
 
     it('should add new action schedule entries for the renewed member', () => {
-      const member = { Email: "test1@example.com", Period: 1, first: "John", last: "Doe", Joined: utils.dateOnly('2021-01-01'), Expires: utils.addYearsToDate(today, 1), "Renewed On": today };
+  const member = { Email: "test1@example.com", Period: 1, first: "John", last: "Doe", Joined: '2021-01-01', Expires: utils.addYearsToDate(today, 1), "Renewed On": today };
       const expected = [
         { Email: member.Email, Type: utils.ActionType.Expiry1, Date: utils.addDaysToDate(member.Expires, O1), },
         { Email: member.Email, Type: utils.ActionType.Expiry2, Date: utils.addDaysToDate(member.Expires, O2), },
@@ -729,17 +729,17 @@ describe('Manager tests', () => {
       ];
 
       const expirySchedule = [
-        { Email: 'captenphil@aol.com', Type: utils.ActionType.Expiry1, Date: utils.dateOnly('12/1/2026') },
-        { Email: 'captenphil@aol.com', Type: utils.ActionType.Expiry2, Date: utils.dateOnly('12/16/2026') },
-        { Email: 'captenphil@aol.com', Type: utils.ActionType.Expiry3, Date: utils.dateOnly('12/31/2026') },
-        { Email: 'captenphil@aol.com', Type: utils.ActionType.Expiry4, Date: utils.dateOnly('1/15/2027') }
+  { Email: 'captenphil@aol.com', Type: utils.ActionType.Expiry1, Date: utils.toIsoDateString('12/1/2026') },
+  { Email: 'captenphil@aol.com', Type: utils.ActionType.Expiry2, Date: utils.toIsoDateString('12/16/2026') },
+  { Email: 'captenphil@aol.com', Type: utils.ActionType.Expiry3, Date: utils.toIsoDateString('12/31/2026') },
+  { Email: 'captenphil@aol.com', Type: utils.ActionType.Expiry4, Date: utils.toIsoDateString('1/15/2027') }
       ];
 
       const expectedExpirySchedule = [
-        { Email: 'phil.stotts@gmail.com', Type: utils.ActionType.Expiry1, Date: utils.dateOnly('12/5/2028') },
-        { Email: 'phil.stotts@gmail.com', Type: utils.ActionType.Expiry2, Date: utils.dateOnly('12/10/2028') },
-        { Email: 'phil.stotts@gmail.com', Type: utils.ActionType.Expiry3, Date: utils.dateOnly('12/15/2028') },
-        { Email: 'phil.stotts@gmail.com', Type: utils.ActionType.Expiry4, Date: utils.dateOnly('12/25/2028') }
+  { Email: 'phil.stotts@gmail.com', Type: utils.ActionType.Expiry1, Date: utils.toIsoDateString('12/5/2028') },
+  { Email: 'phil.stotts@gmail.com', Type: utils.ActionType.Expiry2, Date: utils.toIsoDateString('12/10/2028') },
+  { Email: 'phil.stotts@gmail.com', Type: utils.ActionType.Expiry3, Date: utils.toIsoDateString('12/15/2028') },
+  { Email: 'phil.stotts@gmail.com', Type: utils.ActionType.Expiry4, Date: utils.toIsoDateString('12/25/2028') }
       ];
 
       const expectedMembershipData = {
@@ -748,14 +748,14 @@ describe('Manager tests', () => {
         First: 'Phil',
         Last: 'Stotts',
         Phone: '(831) 345-9634',
-        Joined: new Date('8/8/2017'),
-        Expires: new Date('12/15/2028'),
+        Joined: utils.toIsoDateString('8/8/2017'),
+        Expires: utils.toIsoDateString('12/15/2028'),
         Period: 2,
         'Directory Share Name': true,
         'Directory Share Email': true,
         'Directory Share Phone': true,
-        Migrated: new Date('3/17/2025'),
-        'Renewed On': new Date('10/23/2025')
+        Migrated: utils.toIsoDateString('3/17/2025'),
+        'Renewed On': utils.toIsoDateString('10/23/2025')
       };
 
       const result = manager.convertJoinToRenew(0, 1, membershipData, expirySchedule);

--- a/__tests__/Manager.test.js
+++ b/__tests__/Manager.test.js
@@ -149,7 +149,7 @@ describe('Manager tests', () => {
       activeMembers = [
         { Status: 'Active', Email: "a@b.com", Period: 1, First: "John", Last: "Doe", Joined: "2020-03-10", Expires: "2026-11-14", "Renewed On": "" },
       ];
-      expirySchedule= [
+      expirySchedule = [
         { Date: today, Type: utils.ActionType.Expiry1, Email: "a@b.com" },
         { Date: utils.addDaysToDate(today, 5), Type: utils.ActionType.Expiry2, Email: "a@b.com" },
       ];
@@ -185,9 +185,9 @@ describe('Manager tests', () => {
 
       it('should amend the expiry schedule list appropriately', () => {
         let expectedExpirySchedule = [
-        { Date: new Date('2050-01-01'), Type: utils.ActionType.Expiry1, Email: "test1@example.com" },
-        { Date: new Date('2045-01-01'), Type: utils.ActionType.Expiry3, Email: "test3@example.com" },
-      ];
+          { Date: new Date('2050-01-01'), Type: utils.ActionType.Expiry1, Email: "test1@example.com" },
+          { Date: new Date('2045-01-01'), Type: utils.ActionType.Expiry3, Email: "test3@example.com" },
+        ];
         manager.processExpirations(activeMembers, expirySchedule, PREFILL_FORM_TEMPLATE);
         expect(expirySchedule).toEqual(expectedExpirySchedule)
       })
@@ -195,10 +195,14 @@ describe('Manager tests', () => {
     describe('multiple expiry schedules on the same day for the same address', () => {
       let expectedActiveMembers;
       beforeEach(() => {
-        activeMembers = [{ Status: 'Active', Email: "test1@example.com", Period: 1, First: "John", Last: "Doe", Joined: "2020-03-10", Expires: "2021-01-10", "Renewed On": "" }];
+        activeMembers = [
+          { Status: 'Active', Email: "test1@example.com", Period: 1, First: "John", Last: "Doe", Joined: "2020-03-10", Expires: "2021-01-10", "Renewed On": "" },
+          { Status: 'Active', Email: "test2@example.com", Period: 1, First: "John", Last: "Doe", Joined: "2020-03-10", Expires: "2021-01-10", "Renewed On": "" },
+        ];
         expirySchedule = [
           { Date: today, Type: utils.ActionType.Expiry2, Email: "test1@example.com" },
-          { Date: today, Type: utils.ActionType.Expiry4, Email: "test1@example.com" }
+          { Date: today, Type: utils.ActionType.Expiry4, Email: "test1@example.com" },
+          { Date: '2099-10-10', Type: utils.ActionType.Expiry2, Email: "test2@example.com" }
         ];
       })
       it('should count both schedules as having been processed', () => {
@@ -210,7 +214,10 @@ describe('Manager tests', () => {
         expect(consoleSpy).toHaveBeenCalledWith("Skipping test1@example.com for Expiry2 - already processed");
       })
       it('should process only the latest expiry', () => {
-        expectedActiveMembers = [{ ...activeMembers[0], Status: 'Expired' }];
+        expectedActiveMembers = [
+          { ...activeMembers[0], Status: 'Expired' },
+          { ...activeMembers[1], Status: 'Active' }
+        ];
         manager.processExpirations(activeMembers, expirySchedule, PREFILL_FORM_TEMPLATE);
         expect(activeMembers).toEqual(expectedActiveMembers);
         expect(groupManager.groupRemoveFun).toHaveBeenCalledTimes(2);
@@ -222,7 +229,7 @@ describe('Manager tests', () => {
       it('should remove all schedules for the expiring member', () => {
         expirySchedule.push({ Date: utils.addDaysToDate(today, +3), Type: utils.ActionType.Expiry2, Email: "test1@example.com" })
         manager.processExpirations(activeMembers, expirySchedule, PREFILL_FORM_TEMPLATE);
-        expect(expirySchedule).toEqual([]);
+        expect(expirySchedule).toEqual([{ Date: new Date('2099-10-10:00:00:00Z'), Type: utils.ActionType.Expiry2, Email: "test2@example.com" }]);
       })
     });
     describe('Expiry4 processing', () => {

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -1,0 +1,134 @@
+# Migration plan: move internal dates to canonical ISO (YYYY-MM-DD)
+
+This document captures the design rationale, the safe migration checklist, helper API contracts, testing guidance, and a draft PR body for consolidating the work already on `fix/move-to-canonical-date-string`.
+
+Summary
+-------
+- Goal: make the codebase use a canonical, deterministic, date-only internal representation: the ISO date string `YYYY-MM-DD`.
+- Scope: small, incremental, non-breaking changes only. Do not deploy to production until spreadsheet migration is validated.
+- Current state: `Manager` & its unit tests have been updated on branch `fix/move-to-canonical-date-string` to use ISO strings. This branch is meant to be reviewed and staged for follow-up work (sheet migration).
+
+Design decisions & rationale
+----------------------------
+- Canonical internal representation: `YYYY-MM-DD` (text). Reasons: deterministic comparisons, lexical sort == chronological sort, timezone-agnostic when stored as date-only.
+- Sheet policy (recommended): keep canonical ISO strings in a data column (hidden if desired) and maintain a date-typed display column for users to view and sort naturally. This is reversible and low-risk.
+- Conversion policy: never implicitly convert values when reading sheets. Use explicit helper `parseSheetDate` to read and `writeDateToSheet` to write, with a feature flag gating writes to production cells.
+
+Safe migration checklist (high level)
+-----------------------------------
+1. Backup & test copy
+   - Make a full copy: File → Make a copy in Google Sheets. Label it `MIGRATION TEST - DO NOT EDIT`.
+   - Export critical sheets as CSV for offline backup.
+
+2. Add non-breaking helpers (read-only)
+   - Implement `MembershipManagement.Utils.parseSheetDate(value, options)` that returns `''` for blank/unparseable or `YYYY-MM-DD` for parsed values.
+   - Implement `MembershipManagement.Utils.writeDateToSheet(iso, sheet, row, col, opts)` (but gate its usage). The repo should only add these helpers now; writing logic stays unused until cutover.
+
+3. Dry-run migration on test copy
+   - Add two columns per date field: `Expires (ISO)` and `Expires (Display)`.
+   - Run a dry-run script that reads the old column, normalizes with `parseSheetDate`, writes ISO to `Expires (ISO)` and a date-typed construct to `Expires (Display)` (or formula). The script must generate a CSV audit report and not modify original columns.
+
+4. Validate
+   - Verify sorting on both `Expires (ISO)` (lexicographic) and `Expires (Display)` (date-typed) produce identical chronological order.
+   - Check dependent formulas, filters, and scripts for broken references.
+   - Spot check edge cases: blank cells, locale strings (MM/DD/YYYY vs DD/MM/YYYY), date-time strings (strip time), serial numbers and formula results.
+
+5. Production cutover (apply mode)
+   - After validation, run the migration against production using the script’s `apply` mode.
+   - Keep the original column for a grace period or replace it with ISO depending on downstream needs.
+   - Flip the `writeDatesToSheets` feature flag only when you are ready to have application code update sheets.
+
+Rollback
+--------
+- Use the CSV audit file produced by the dry-run / apply script to restore original values if needed.
+- If code got merged and deployed prematurely: prefer `git revert <merge-commit>` and restore the sheet from backup.
+
+Helper API contract (spec)
+-------------------------
+- parseSheetDate(value, options = {})
+  - Accepts: Date object, number (sheet serial), ISO string, locale string, or null/empty
+  - options.sheetLocale: 'US' | 'EU' | 'ISO' (default 'US')
+  - Returns: ISO string `YYYY-MM-DD` on success, `''` for blank, `null` or `''` for unparseable (caller should flag)
+  - Behavior: for Date inputs, convert to UTC-midnight and return ISO to avoid timezone shift. For numeric serials, convert to date using spreadsheet epoch conversion.
+
+- writeDateToSheet(iso, sheet, row, col, opts = {})
+  - opts.asDateCell (default true): if true, write a Date object (UTC-midnight) so Sheets treats the cell as date-typed; otherwise write the ISO text.
+  - Must be used only when `writeDatesToSheets` flag is enabled.
+
+Small implementation notes
+--------------------------
+- When creating Date objects for Sheets, use `new Date(Date.UTC(y, m-1, d))` to avoid timezone shifts when the sheet timezone is not UTC.
+- Formula-based display option (no script required):
+  - Given ISO in A2, display date typed value with:
+    =DATE(VALUE(LEFT(A2,4)), VALUE(MID(A2,6,2)), VALUE(RIGHT(A2,2)))
+  - After verifying, copy→Paste special→Values to convert formula results into static date values.
+
+Validation checklist (pre-deploy)
+-------------------------------
+- All unit tests pass locally (run `npm test`).
+- `__tests__/Manager.test.js` remains green with canonical expectations.
+- Dry-run CSV: no unparseable rows (or manual review list handled).
+- User acceptance: at least one member test user sorts and inspects the display column and finds behavior acceptable.
+
+Draft PR body (copy-paste into PR when ready)
+-------------------------------------------
+Title: WIP: Move internal dates to canonical ISO (YYYY-MM-DD) — DO NOT MERGE
+
+Body:
+```
+Summary
+-------
+This PR is a work-in-progress that moves internal date handling toward a canonical, date-only ISO representation (`YYYY-MM-DD`). It is intentionally marked WIP/draft and must NOT be merged or deployed until spreadsheet migration and UI validation are complete.
+
+Files changed (high-level)
+- `src/services/MembershipManagement/utils.js` — added/updated canonical helpers (parse/add/iso helpers)
+- `src/services/MembershipManagement/Manager.js` — internal fields now use ISO date-only strings (non-deploy until sheet migration)
+- `__tests__/Manager.test.js` — updated expectations to assert ISO strings
+
+What remains
+- Implement and validate `parseSheetDate` and a dry-run migration on a test copy of the spreadsheet.
+- Add a feature flag `writeDatesToSheets` (default false) to prevent any writes to live sheet cells until migration is complete.
+- Update dependent sheets/formulas to reference new display columns where appropriate.
+
+Migration plan
+- See `docs/MIGRATION_PLAN.md` (included in this PR) for an ordered checklist: backup -> helpers -> dry-run -> validate -> cutover
+
+Testing
+- Unit tests updated for Manager — run `npm test` locally. Do not deploy until manual sheet validation is complete.
+
+Notes & rollback
+- Keep the branch open and the PR in WIP state. If this is merged prematurely, revert with `git revert` and restore the sheet from backups.
+
+```
+
+Suggested reviewers: @yourself, any owner of the sheets or membership workflows
+
+— end PR body
+
+Next steps I can help with
+-------------------------
+- Add `parseSheetDate` and `writeDateToSheet` helpers (non-breaking). I can create the helper in `src/services/MembershipManagement/utils.js` and unit tests for it.
+- Create the dry-run migration script (`scripts/migrate_dates.js` or `src/gas/migrate_dates.gs`) and a CSV audit output.
+
+If you want, I can open a draft PR for you. Otherwise push and open it yourself. Suggested local commands:
+
+```bash
+# run tests
+npm test
+
+# commit any remaining work
+git add -A
+git commit -m "WIP: canonical date internals (ISO YYYY-MM-DD) + migration doc"
+git push -u origin fix/move-to-canonical-date-string
+
+# if you use GitHub CLI to open a draft PR:
+gh pr create --title "WIP: Move internal dates to canonical ISO (YYYY-MM-DD) — DO NOT MERGE" \
+  --body-file docs/MIGRATION_PLAN.md --draft --base main
+```
+
+Questions / notes
+-----------------
+- Do you want me to open the draft PR for you, or would you like to push and open it yourself? If you want me to open it, I will need your confirmation to run the push/open PR steps (I can prepare the commit locally and add the doc file now).
+
+---
+Generated on: 2025-11-15

--- a/src/services/MembershipManagement/MembershipManagement.js
+++ b/src/services/MembershipManagement/MembershipManagement.js
@@ -73,8 +73,11 @@ MembershipManagement.processExpirations = function () {
     const expiryScheduleFiddler = Common.Data.Storage.SpreadsheetManager.getFiddler('ExpirySchedule');
 
     const { manager, membershipData, expiryScheduleData } = this.Internal.initializeManagerData_(membershipFiddler, expiryScheduleFiddler);
-
-    const numProcessed = manager.processExpirations(membershipData, expiryScheduleData);
+    const prefillFormTemplate = PropertiesService.getScriptProperties().getProperty('PREFILL_FORM_TEMPLATE');
+    if (!prefillFormTemplate) {
+      throw new Error("PREFILL_FORM_TEMPLATE property is not set.");
+    }
+    const numProcessed = manager.processExpirations(membershipData, expiryScheduleData, prefillFormTemplate);
 
     if (numProcessed === 0) {
       MembershipManagement.Utils.log('No memberships required expiration processing');

--- a/src/services/MembershipManagement/Menu.js
+++ b/src/services/MembershipManagement/Menu.js
@@ -5,8 +5,8 @@ MembershipManagement.Menu = {
             .addItem('Process Transactions', processTransactions.name)
             .addItem('Process Expirations', processExpirations.name)
             .addSeparator()
-            .addItem('Merge Selected Members', mergeSelectedMembers.name)
             .addItem('Find possible renewals', findPossibleRenewalsFromMenu.name)
+            .addItem('Merge Selected Members', mergeSelectedMembers.name)
             .addSeparator()
             .addItem('Process Migrations', processMigrations.name)
             .addToUi();

--- a/src/services/MembershipManagement/utils.js
+++ b/src/services/MembershipManagement/utils.js
@@ -1,6 +1,8 @@
 
 if (typeof require !== 'undefined') {
-   MembershipManagement = { Utils: {} };
+  // When running under Node tests, ensure MembershipManagement exists.
+  // We don't populate the full shape here; module.exports at file end will export MembershipManagement.
+  global.MembershipManagement = global.MembershipManagement || { Utils: {} };
 }
 
 
@@ -15,16 +17,69 @@ if (typeof require !== 'undefined') {
     }
   };
 
-  MembershipManagement.Utils.addDaysToDate = function(date, days = 0) {
-    const result = this.dateOnly(date);
-    result.setDate(result.getDate() + days);
-    return result;
+  // --- Canonical ISO date helpers ---
+  // Internal canonical representation: "YYYY-MM-DD" strings.
+  // toIsoDateString accepts a Date or a YYYY-MM-DD string and returns a canonical YYYY-MM-DD string
+  MembershipManagement.Utils.toIsoDateString = function(dateLike) {
+    if (!dateLike) {
+      const now = new Date();
+      const y = now.getUTCFullYear();
+      const m = now.getUTCMonth() + 1;
+      const d = now.getUTCDate();
+      return `${y.toString().padStart(4,'0')}-${m.toString().padStart(2,'0')}-${d.toString().padStart(2,'0')}`;
+    }
+    if (typeof dateLike === 'string') {
+      const isoMatch = dateLike.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+      if (isoMatch) return dateLike;
+      // Deterministic fallback: parse via Date and use UTC components
+      const parsed = new Date(dateLike);
+      if (isNaN(parsed.getTime())) throw new Error(`Invalid date string: ${dateLike}`);
+      const y = parsed.getUTCFullYear();
+      const m = parsed.getUTCMonth() + 1;
+      const d = parsed.getUTCDate();
+      return `${y.toString().padStart(4,'0')}-${m.toString().padStart(2,'0')}-${d.toString().padStart(2,'0')}`;
+    }
+    if (dateLike instanceof Date) {
+      const y = dateLike.getUTCFullYear();
+      const m = dateLike.getUTCMonth() + 1;
+      const d = dateLike.getUTCDate();
+      return `${y.toString().padStart(4,'0')}-${m.toString().padStart(2,'0')}-${d.toString().padStart(2,'0')}`;
+    }
+    // Last resort: coerce and recurse
+    const coerced = new Date(dateLike);
+    if (isNaN(coerced.getTime())) throw new Error(`Invalid dateLike: ${dateLike}`);
+    return MembershipManagement.Utils.toIsoDateString(coerced);
   };
 
-  MembershipManagement.Utils.addYearsToDate = function(date, years = 0) {
-    const result = this.dateOnly(date);
-    result.setFullYear(result.getFullYear() + years);
-    return result;
+  // Convert ISO string YYYY-MM-DD to a UTC-midnight Date object
+  MembershipManagement.Utils.isoToDate = function(iso) {
+    if (!iso) return new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate()));
+    const m = iso.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!m) throw new Error(`Invalid ISO date: ${iso}`);
+    const y = Number(m[1]);
+    const mo = Number(m[2]) - 1;
+    const d = Number(m[3]);
+    return new Date(Date.UTC(y, mo, d));
+  };
+
+  // addDaysToDate/addYearsToDate operate on inputs that can be Date or ISO string and return ISO strings
+  MembershipManagement.Utils.addDaysToDate = function(dateLike, days = 0) {
+    const iso = this.toIsoDateString(dateLike);
+    const baseDate = this.isoToDate(iso);
+    const epochDays = Math.floor(baseDate.getTime() / 86400000) + Number(days);
+    const resultDate = new Date(epochDays * 86400000);
+    return this.toIsoDateString(resultDate);
+  };
+
+  MembershipManagement.Utils.addYearsToDate = function(dateLike, years = 0) {
+    const iso = this.toIsoDateString(dateLike);
+    const baseDate = this.isoToDate(iso);
+    const y = baseDate.getUTCFullYear() + Number(years);
+    const mo = baseDate.getUTCMonth();
+    const d = baseDate.getUTCDate();
+    // Construct in UTC to avoid timezone shifts
+    const resultDate = new Date(Date.UTC(y, mo, d));
+    return this.toIsoDateString(resultDate);
   };
   MembershipManagement.Utils.ActionType = {
     Join: 'Join',
@@ -39,7 +94,13 @@ if (typeof require !== 'undefined') {
   
 
   MembershipManagement.Utils.toLocaleDateString = function(date) {
-    return new Date(date).toLocaleDateString()
+    // Accept ISO date strings or Date objects and return a locale date string
+    try {
+      const d = (typeof date === 'string') ? MembershipManagement.Utils.isoToDate(date) : new Date(date);
+      return d.toLocaleDateString();
+    } catch (e) {
+      return '' + date;
+    }
   };
 
 
@@ -55,9 +116,10 @@ if (typeof require !== 'undefined') {
   MembershipManagement.Utils.calculateExpirationDate = function(referenceDate, expires, period = 1) {
     if (!referenceDate) throw new Error('No reference date provided')
     if (!expires) throw new Error('No expiration date provided')
-    referenceDate = this.dateOnly(referenceDate)
-    expires = this.dateOnly(expires)
-    const startDate = referenceDate < expires ? expires : referenceDate
+    // Work in canonical ISO strings so comparisons are deterministic
+    referenceDate = this.toIsoDateString(referenceDate)
+    expires = this.toIsoDateString(expires)
+    const startDate = (referenceDate < expires) ? expires : referenceDate
     const result = this.addYearsToDate(startDate, period);
     return result
   };
@@ -80,12 +142,14 @@ MembershipManagement.Utils.expandTemplate = function(template, row) {
   return template.replace(/{([^}]+)}/g, (_, key) => {
     let value = row[key];
     if (dateFields.includes(key)) {
-      if (typeof value === 'string') {
-        value = new Date(Date.parse(value));
+      // Accept ISO strings or Date objects. Convert to ISO then to a locale string for display.
+      try {
+        const iso = this.toIsoDateString(value);
+        const d = this.isoToDate(iso);
+        return d.toLocaleDateString();
+      } catch (e) {
+        return value || '';
       }
-
-      value = this.dateOnly(value);
-      return value.toLocaleDateString(); // Convert Date objects to local date and time string
     }
     return value || "";
   });

--- a/src/services/MembershipManagement/utils.js
+++ b/src/services/MembershipManagement/utils.js
@@ -98,6 +98,22 @@ MembershipManagement.Utils.dateOnly = function(date)  {
   return dateOnly;
 }
 
+/**
+ * 
+ * @param {Member} member 
+ * @param {string} prefillFormTemplate 
+ * @returns {Member} copy of member with Form key added whose value is the html link to the prefilled renewal form for this member
+ */
+MembershipManagement.Utils.addPrefillForm = function(member, prefillFormTemplate)  {
+  const memberCopy = { ...member, Form: null }; // Create a shallow copy to avoid mutating the original member
+  const memberAsQueryParams = Object.fromEntries(
+    Object.entries(member).map(([k, v]) => [k, encodeURIComponent(v)])
+  );
+  const prefillFormUrl = MembershipManagement.Utils.expandTemplate(prefillFormTemplate, memberAsQueryParams);
+  memberCopy.Form = `<a href="${prefillFormUrl}">renewal form</a>`;
+  return memberCopy;
+}
+
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = MembershipManagement;
 }


### PR DESCRIPTION
# Migration plan: move internal dates to canonical ISO (YYYY-MM-DD)

This document captures the design rationale, the safe migration checklist, helper API contracts, testing guidance, and a draft PR body for consolidating the work already on `fix/move-to-canonical-date-string`.

Summary
-------
- Goal: make the codebase use a canonical, deterministic, date-only internal representation: the ISO date string `YYYY-MM-DD`.
- Scope: small, incremental, non-breaking changes only. Do not deploy to production until spreadsheet migration is validated.
- Current state: `Manager` & its unit tests have been updated on branch `fix/move-to-canonical-date-string` to use ISO strings. This branch is meant to be reviewed and staged for follow-up work (sheet migration).

Design decisions & rationale
----------------------------
- Canonical internal representation: `YYYY-MM-DD` (text). Reasons: deterministic comparisons, lexical sort == chronological sort, timezone-agnostic when stored as date-only.
- Sheet policy (recommended): keep canonical ISO strings in a data column (hidden if desired) and maintain a date-typed display column for users to view and sort naturally. This is reversible and low-risk.
- Conversion policy: never implicitly convert values when reading sheets. Use explicit helper `parseSheetDate` to read and `writeDateToSheet` to write, with a feature flag gating writes to production cells.

Safe migration checklist (high level)
-----------------------------------
1. Backup & test copy
   - Make a full copy: File → Make a copy in Google Sheets. Label it `MIGRATION TEST - DO NOT EDIT`.
   - Export critical sheets as CSV for offline backup.

2. Add non-breaking helpers (read-only)
   - Implement `MembershipManagement.Utils.parseSheetDate(value, options)` that returns `''` for blank/unparseable or `YYYY-MM-DD` for parsed values.
   - Implement `MembershipManagement.Utils.writeDateToSheet(iso, sheet, row, col, opts)` (but gate its usage). The repo should only add these helpers now; writing logic stays unused until cutover.

3. Dry-run migration on test copy
   - Add two columns per date field: `Expires (ISO)` and `Expires (Display)`.
   - Run a dry-run script that reads the old column, normalizes with `parseSheetDate`, writes ISO to `Expires (ISO)` and a date-typed construct to `Expires (Display)` (or formula). The script must generate a CSV audit report and not modify original columns.

4. Validate
   - Verify sorting on both `Expires (ISO)` (lexicographic) and `Expires (Display)` (date-typed) produce identical chronological order.
   - Check dependent formulas, filters, and scripts for broken references.
   - Spot check edge cases: blank cells, locale strings (MM/DD/YYYY vs DD/MM/YYYY), date-time strings (strip time), serial numbers and formula results.

5. Production cutover (apply mode)
   - After validation, run the migration against production using the script’s `apply` mode.
   - Keep the original column for a grace period or replace it with ISO depending on downstream needs.
   - Flip the `writeDatesToSheets` feature flag only when you are ready to have application code update sheets.

Rollback
--------
- Use the CSV audit file produced by the dry-run / apply script to restore original values if needed.
- If code got merged and deployed prematurely: prefer `git revert <merge-commit>` and restore the sheet from backup.

Helper API contract (spec)
-------------------------
- parseSheetDate(value, options = {})
  - Accepts: Date object, number (sheet serial), ISO string, locale string, or null/empty
  - options.sheetLocale: 'US' | 'EU' | 'ISO' (default 'US')
  - Returns: ISO string `YYYY-MM-DD` on success, `''` for blank, `null` or `''` for unparseable (caller should flag)
  - Behavior: for Date inputs, convert to UTC-midnight and return ISO to avoid timezone shift. For numeric serials, convert to date using spreadsheet epoch conversion.

- writeDateToSheet(iso, sheet, row, col, opts = {})
  - opts.asDateCell (default true): if true, write a Date object (UTC-midnight) so Sheets treats the cell as date-typed; otherwise write the ISO text.
  - Must be used only when `writeDatesToSheets` flag is enabled.

Small implementation notes
--------------------------
- When creating Date objects for Sheets, use `new Date(Date.UTC(y, m-1, d))` to avoid timezone shifts when the sheet timezone is not UTC.
- Formula-based display option (no script required):
  - Given ISO in A2, display date typed value with:
    =DATE(VALUE(LEFT(A2,4)), VALUE(MID(A2,6,2)), VALUE(RIGHT(A2,2)))
  - After verifying, copy→Paste special→Values to convert formula results into static date values.

Validation checklist (pre-deploy)
-------------------------------
- All unit tests pass locally (run `npm test`).
- `__tests__/Manager.test.js` remains green with canonical expectations.
- Dry-run CSV: no unparseable rows (or manual review list handled).
- User acceptance: at least one member test user sorts and inspects the display column and finds behavior acceptable.

Draft PR body (copy-paste into PR when ready)
-------------------------------------------
Title: WIP: Move internal dates to canonical ISO (YYYY-MM-DD) — DO NOT MERGE

Body:
```
Summary
-------
This PR is a work-in-progress that moves internal date handling toward a canonical, date-only ISO representation (`YYYY-MM-DD`). It is intentionally marked WIP/draft and must NOT be merged or deployed until spreadsheet migration and UI validation are complete.

Files changed (high-level)
- `src/services/MembershipManagement/utils.js` — added/updated canonical helpers (parse/add/iso helpers)
- `src/services/MembershipManagement/Manager.js` — internal fields now use ISO date-only strings (non-deploy until sheet migration)
- `__tests__/Manager.test.js` — updated expectations to assert ISO strings

What remains
- Implement and validate `parseSheetDate` and a dry-run migration on a test copy of the spreadsheet.
- Add a feature flag `writeDatesToSheets` (default false) to prevent any writes to live sheet cells until migration is complete.
- Update dependent sheets/formulas to reference new display columns where appropriate.

Migration plan
- See `docs/MIGRATION_PLAN.md` (included in this PR) for an ordered checklist: backup -> helpers -> dry-run -> validate -> cutover

Testing
- Unit tests updated for Manager — run `npm test` locally. Do not deploy until manual sheet validation is complete.

Notes & rollback
- Keep the branch open and the PR in WIP state. If this is merged prematurely, revert with `git revert` and restore the sheet from backups.

```

Suggested reviewers: @yourself, any owner of the sheets or membership workflows

— end PR body

Next steps I can help with
-------------------------
- Add `parseSheetDate` and `writeDateToSheet` helpers (non-breaking). I can create the helper in `src/services/MembershipManagement/utils.js` and unit tests for it.
- Create the dry-run migration script (`scripts/migrate_dates.js` or `src/gas/migrate_dates.gs`) and a CSV audit output.

If you want, I can open a draft PR for you. Otherwise push and open it yourself. Suggested local commands:

```bash
# run tests
npm test

# commit any remaining work
git add -A
git commit -m "WIP: canonical date internals (ISO YYYY-MM-DD) + migration doc"
git push -u origin fix/move-to-canonical-date-string

# if you use GitHub CLI to open a draft PR:
gh pr create --title "WIP: Move internal dates to canonical ISO (YYYY-MM-DD) — DO NOT MERGE" \
  --body-file docs/MIGRATION_PLAN.md --draft --base main
```

Questions / notes
-----------------
- Do you want me to open the draft PR for you, or would you like to push and open it yourself? If you want me to open it, I will need your confirmation to run the push/open PR steps (I can prepare the commit locally and add the doc file now).

---
Generated on: 2025-11-15
