### PR TITLE
Refactor Manager to return errors instead of throwing

### DIFF
--- a/docs/ISSUE-AGGREGATEERROR.md
+++ b/docs/ISSUE-AGGREGATEERROR.md
@@ -1,0 +1,71 @@
+Title: Inconsistent use of AggregateError in MembershipManagement.Manager — refactor to return errors
+
+Summary
+
+Several Manager methods in `src/services/MembershipManagement/Manager.js` handle batch errors inconsistently. Some methods throw an `AggregateError` (e.g. `migrateCEMembers`), while others return an `errors` array as part of their return value (e.g. `processPaidTransactions` and `processExpiredMembers` returns failed items). This inconsistency makes it difficult for callers and tests to reliably consume partial successes and failures and complicates wrapper logic and audit patterns.
+
+Files/locations affected
+
+- `src/services/MembershipManagement/Manager.js`
+  - `generateExpiringMembersList` (dead `AggregateError` throw; `errors` is never populated)
+  - `migrateCEMembers` (throws `AggregateError` on any migration error)
+  - `processPaidTransactions` (already returns `errors` array)
+  - `processExpiredMembers` (already returns structured `failed`/`processed` arrays)
+- Tests:
+  - `__tests__/Manager.test.js` (contains tests expecting `AggregateError` in migration failure scenario)
+
+Problem details / reproduction
+
+1. `migrateCEMembers` collects per-row errors into an `errors` array and at the end does: `if (errors.length > 0) { throw new AggregateError(errors, 'Errors occurred while migrating members'); }`. This causes the entire migration operation to throw on any failure, preventing callers from receiving a partial success result and the `auditEntries` and `numMigrations` in a structured way.
+
+2. `generateExpiringMembersList` contains a check that throws `AggregateError` if `errors.length > 0`, but in the current implementation `errors` is never populated, so the throw is effectively dead code. This is confusing and should be cleaned up.
+
+Why this matters
+
+- Generator/consumer pattern in this codebase prefers generators to return data (including partial errors) and keep side-effects in consumers.
+- Throwing `AggregateError` breaks this pattern and forces higher layers to use exception handling instead of examining structured results.
+- Tests and wrappers must handle both thrown errors and returned errors, increasing complexity.
+
+Proposed change (high level)
+
+- Align Manager methods to a single error-handling pattern: return errors as data rather than throwing.
+  - `migrateCEMembers` should return `{ numMigrations, auditEntries, errors }` and NOT throw.
+  - Remove the dead `AggregateError` throw in `generateExpiringMembersList`. Either populate `errors` or remove the check entirely.
+- Update callers and wrappers (if any) that currently expect exceptions from `migrateCEMembers` to handle returned `errors` instead.
+- Update tests in `__tests__/Manager.test.js` to assert on returned `errors` rather than expecting an exception.
+
+Acceptance criteria
+
+- `migrateCEMembers` returns `{ numMigrations, auditEntries, errors }` and does not throw on partial failures.
+- `generateExpiringMembersList` no longer contains dead/unused `AggregateError` throws.
+- Tests updated: migration failure test inspects returned `errors` array and `auditEntries` rather than catching `AggregateError`.
+- All existing tests pass (or are updated) and new behavior is documented in the issue/PR.
+
+Suggested implementation notes
+
+- Change `migrateCEMembers`:
+  - At the end, `return { numMigrations, auditEntries, errors };` instead of throwing. Keep `errors` populated as currently done.
+  - Update any code that called it and expected an exception.
+- Change `generateExpiringMembersList`:
+  - Remove `errors` array and the `if (errors.length > 0) { throw ... }` check, or make sure `errors` is actually used if intended.
+- Update tests accordingly.
+
+Risk and impact
+
+- Medium: touches core business logic and tests. Should be done in its own focused PR to limit scope.
+- Backwards compatibility: Callers expecting thrown exceptions will need to be updated; however, the rest of the codebase already contains methods that return structured error data (good precedent).
+
+Notes / Implementation checklist
+
+- [ ] Create a feature branch `fix/migrate-return-errors` (or similar)
+- [ ] Modify `migrateCEMembers` and `generateExpiringMembersList` in `src/services/MembershipManagement/Manager.js`
+- [ ] Update tests in `__tests__/Manager.test.js` to inspect returned `errors`
+- [ ] Run `npm test` and fix regressions
+- [ ] Create PR referencing this issue and update release notes
+
+References
+
+- Related PR: https://github.com/TobyHFerguson/SCCCCMembershipManagement/pull/272 (current audit-trail work)
+- Context: generator/consumer separation pattern in `copilot-instructions.md` and project docs
+
+Reporter: @toby (drafted by Copilot)

--- a/docs/PR-AGGREGATEERROR.md
+++ b/docs/PR-AGGREGATEERROR.md
@@ -1,0 +1,86 @@
+PR Draft: Refactor Manager to return errors instead of throwing AggregateError
+
+Branch: `fix/migrate-return-errors`
+
+Title: Refactor MembershipManagement.Manager to return errors (avoid AggregateError throws)
+
+Summary
+
+This PR refactors error handling in `MembershipManagement.Manager` to make it consistent with the generator/consumer pattern used across the codebase. Specifically, it removes throwing `AggregateError` from manager-level methods and returns `errors` arrays as part of the method return values. This enables consumers and wrappers to handle partial successes and failures deterministically and simplifies audit handling.
+
+Files to change (high level)
+
+- `src/services/MembershipManagement/Manager.js`
+  - `generateExpiringMembersList`
+    - Remove dead `AggregateError` throw. Ensure returned shape remains `{ messages, auditEntries }` or include `errors` if needed.
+  - `migrateCEMembers`
+    - Replace `throw new AggregateError(errors, ...)` with `return { numMigrations, auditEntries, errors }`.
+- `__tests__/Manager.test.js`
+  - Replace tests that expect thrown `AggregateError` with assertions that inspect returned `errors` and `auditEntries`.
+
+Why this approach
+
+- Matches `processPaidTransactions` and `processExpiredMembers`, which already return errors/data rather than throwing.
+- Keeps generator methods pure and returns useful diagnostics to the caller.
+- Avoids exception-driven logic for routine partial failures.
+
+Detailed change plan
+
+1) Create branch `fix/migrate-return-errors` from `copilot/add-audit-trail-to-spreadsheet` (or `main` depending on workflow).
+
+2) Code changes in `Manager.js`:
+   - In `migrateCEMembers`, after the migration loop, replace the block:
+
+```js
+    if (errors.length > 0) {
+      throw new AggregateError(errors, 'Errors occurred while migrating members');
+    }
+    return { numMigrations, auditEntries };
+```
+
+with
+
+```js
+    return { numMigrations, auditEntries, errors };
+```
+
+   - In `generateExpiringMembersList`, remove the unused `errors` array and the `if (errors.length > 0)` check. If we want to preserve an `errors` return for consistency, change the return signature to `{ messages, auditEntries, errors }` and populate `errors` appropriately.
+
+3) Update tests in `__tests__/Manager.test.js`:
+   - Modify the migration failure test to call `migrateCEMembers()` and assert that the returned `errors.length > 0`, and that `auditEntries` contains the expected failure audit entries.
+   - Update any other tests that expected `AggregateError` to instead assert on returned `errors`.
+
+4) Run tests and iterate until green.
+
+5) Update changelog and release notes: explain the behavioral change in Manager API (returning `errors` instead of throwing). Add migration notes if external callers depend on exception behavior.
+
+Checklist (PR template)
+
+- [ ] Branch created: `fix/migrate-return-errors`
+- [ ] `migrateCEMembers` refactored to return `errors`
+- [ ] `generateExpiringMembersList` cleaned up (dead `AggregateError` removed)
+- [ ] Tests updated and passing (`npm test`)
+- [ ] PR description references `docs/ISSUE-AGGREGATEERROR.md`
+- [ ] README/Docs updated (if necessary)
+
+Commands
+
+Create branch and push:
+
+```bash
+# from repo root
+git checkout -b fix/migrate-return-errors
+# make changes
+git add src/services/MembershipManagement/Manager.js __tests__/Manager.test.js
+git commit -m "Refactor: return errors from migrateCEMembers; remove dead AggregateError" 
+git push -u origin fix/migrate-return-errors
+# open PR via gh CLI
+gh pr create --base main --head fix/migrate-return-errors --title "Refactor Manager to return errors instead of throwing" --body-file docs/PR-AGGREGATEERROR.md
+```
+
+Notes for reviewers
+
+- This PR intentionally changes public method return shapes for `migrateCEMembers`. Reviewers should confirm callers are updated or that these methods are internal-only.
+- This refactor improves observability and makes the error handling pattern consistent across Manager methods.
+
+If you want, I can also implement the code changes and tests now on this branch — say the word and I will open the branch, apply the edits, update tests, and run `npm test`.


### PR DESCRIPTION
PR Draft: Refactor Manager to return errors instead of throwing AggregateError

Branch: `fix/migrate-return-errors`

Title: Refactor MembershipManagement.Manager to return errors (avoid AggregateError throws)

Summary

This PR refactors error handling in `MembershipManagement.Manager` to make it consistent with the generator/consumer pattern used across the codebase. Specifically, it removes throwing `AggregateError` from manager-level methods and returns `errors` arrays as part of the method return values. This enables consumers and wrappers to handle partial successes and failures deterministically and simplifies audit handling.

Files to change (high level)

- `src/services/MembershipManagement/Manager.js`
  - `generateExpiringMembersList`
    - Remove dead `AggregateError` throw. Ensure returned shape remains `{ messages, auditEntries }` or include `errors` if needed.
  - `migrateCEMembers`
    - Replace `throw new AggregateError(errors, ...)` with `return { numMigrations, auditEntries, errors }`.
- `__tests__/Manager.test.js`
  - Replace tests that expect thrown `AggregateError` with assertions that inspect returned `errors` and `auditEntries`.

Why this approach

- Matches `processPaidTransactions` and `processExpiredMembers`, which already return errors/data rather than throwing.
- Keeps generator methods pure and returns useful diagnostics to the caller.
- Avoids exception-driven logic for routine partial failures.

Detailed change plan

1) Create branch `fix/migrate-return-errors` from `copilot/add-audit-trail-to-spreadsheet` (or `main` depending on workflow).

2) Code changes in `Manager.js`:
   - In `migrateCEMembers`, after the migration loop, replace the block:

```js
    if (errors.length > 0) {
      throw new AggregateError(errors, 'Errors occurred while migrating members');
    }
    return { numMigrations, auditEntries };
```

with

```js
    return { numMigrations, auditEntries, errors };
```

   - In `generateExpiringMembersList`, remove the unused `errors` array and the `if (errors.length > 0)` check. If we want to preserve an `errors` return for consistency, change the return signature to `{ messages, auditEntries, errors }` and populate `errors` appropriately.

3) Update tests in `__tests__/Manager.test.js`:
   - Modify the migration failure test to call `migrateCEMembers()` and assert that the returned `errors.length > 0`, and that `auditEntries` contains the expected failure audit entries.
   - Update any other tests that expected `AggregateError` to instead assert on returned `errors`.

4) Run tests and iterate until green.

5) Update changelog and release notes: explain the behavioral change in Manager API (returning `errors` instead of throwing). Add migration notes if external callers depend on exception behavior.

Checklist (PR template)

- [ ] Branch created: `fix/migrate-return-errors`
- [ ] `migrateCEMembers` refactored to return `errors`
- [ ] `generateExpiringMembersList` cleaned up (dead `AggregateError` removed)
- [ ] Tests updated and passing (`npm test`)
- [ ] PR description references `docs/ISSUE-AGGREGATEERROR.md`
- [ ] README/Docs updated (if necessary)

Commands

Create branch and push:

```bash
# from repo root
git checkout -b fix/migrate-return-errors
# make changes
git add src/services/MembershipManagement/Manager.js __tests__/Manager.test.js
git commit -m "Refactor: return errors from migrateCEMembers; remove dead AggregateError" 
git push -u origin fix/migrate-return-errors
# open PR via gh CLI
gh pr create --base main --head fix/migrate-return-errors --title "Refactor Manager to return errors instead of throwing" --body-file docs/PR-AGGREGATEERROR.md
```

Notes for reviewers

- This PR intentionally changes public method return shapes for `migrateCEMembers`. Reviewers should confirm callers are updated or that these methods are internal-only.
- This refactor improves observability and makes the error handling pattern consistent across Manager methods.

If you want, I can also implement the code changes and tests now on this branch — say the word and I will open the branch, apply the edits, update tests, and run `npm test`.
